### PR TITLE
Reference the OCaml stdlib functions from the generated code

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,3 @@
 (library
-    (name ppx_mysql_runtime)
-    (public_name ppx_mysql.runtime)
-    (wrapped false))
+  (name ppx_mysql_runtime)
+  (public_name ppx_mysql.runtime))

--- a/lib/ppx_mysql_runtime.ml
+++ b/lib/ppx_mysql_runtime.ml
@@ -3,6 +3,15 @@
 
 (********************************************************************************)
 
+(* This module is required to keep references to the OCaml operators in the stdlib *)
+module Stdlib = struct
+  module Array = Array
+  module String = String
+  module List = List
+
+  let ( = ) = ( = )
+end
+
 let identity x = x
 
 let map_option f = function

--- a/lib/ppx_mysql_runtime.mli
+++ b/lib/ppx_mysql_runtime.mli
@@ -9,3 +9,25 @@ val identity : 'a -> 'a
 val map_option : ('a -> 'b) -> 'a option -> 'b option
 
 val get_option : 'a option -> 'a
+
+module Stdlib : sig
+  module String : sig
+    include module type of struct
+        include String
+    end
+  end
+
+  module Array : sig
+    include module type of struct
+        include Array
+    end
+  end
+
+  module List : sig
+    include module type of struct
+        include List
+    end
+  end
+
+  val ( = ) : 'a -> 'a -> bool
+end

--- a/ppx/dune
+++ b/ppx/dune
@@ -1,7 +1,6 @@
 (library
-    (name ppx_mysql)
-    (public_name ppx_mysql)
-    (wrapped false)
-    (kind ppx_rewriter)
-    (libraries base re ppxlib ppx_mysql.runtime)
-    (preprocess (pps ppxlib.metaquot)))
+  (name ppx_mysql)
+  (public_name ppx_mysql)
+  (kind ppx_rewriter)
+  (libraries base re ppxlib ppx_mysql.runtime)
+  (preprocess (pps ppxlib.metaquot)))


### PR DESCRIPTION
As we've run into issues where the generated code expects the code to have OCaml compiler stdlib semantics but the code in which it might be embedded might do whatever replacements of operators and stdlib modules (e.g. common with Jane Street Core or Base), it is better to avoid capturing altogether, so better reference the exact module to load.

Since the `Stdlib` module was only added in OCaml 4.07 it is a bit early to depend on this, therefore this PR adds a `Ppx_mysql_runtime.Stdlib` module that keeps references to the OCaml Stdlib items that the generated code uses.

It also cleans up the mixing of usage of `Base` and `Caml` variants of code.