### PR TITLE
Do not depend on a specific version of OCamlformat

### DIFF
--- a/ppx_mysql.opam
+++ b/ppx_mysql.opam
@@ -11,7 +11,7 @@ build-test: [["dune" "runtest" "-p" name]]
 depends: [
   "alcotest" {test & >= "0.8" & < "0.9"}
   "dune" {build}
-  "ocamlformat" {test & = "0.7"}
+  "ocamlformat" {test}
   "ppxlib" {>= "0.2" & < "0.4"}
   "ppx_deriving" {test & >= "4.2" & < "5.0"}
 ]

--- a/tests/test_ppx/dune
+++ b/tests/test_ppx/dune
@@ -13,6 +13,11 @@
     (deps test_ppx.result.ml)
     (action (run ocamlformat %{deps} -o %{targets})))
 
+(rule
+    (targets test_ppx.expected.reformatted.ml)
+    (deps test_ppx.expected.ml)
+    (action (run ocamlformat %{deps} -o %{targets})))
+
 (alias
     (name runtest)
-    (action (diff test_ppx.expected.ml test_ppx.result.reformatted.ml)))
+    (action (diff test_ppx.expected.reformatted.ml test_ppx.result.reformatted.ml)))


### PR DESCRIPTION
By passing *both* the ppx result and the expected
output through OCamlformat we don't have to depend
on the vagaries of a specific version of OCamlformat.