### PR TITLE
Fix version constraints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ env:
   global:
     - DEPOPTS="*"
     - TESTS=true
-    - EXTRA_REMOTES="https://github.com/issuu/opam-repository-micro.git"
   matrix:
     - OCAML_VERSION=4.06 PACKAGE="ppx_mysql"          PINS="ppx_mysql:."
     - OCAML_VERSION=4.06 PACKAGE="ppx_mysql_identity" PINS="ppx_mysql:. ppx_mysql_identity:."
     - OCAML_VERSION=4.06 PACKAGE="ppx_mysql_lwt"      PINS="ppx_mysql:. ppx_mysql_lwt:."
-    - OCAML_VERSION=4.06 PACKAGE="ppx_mysql_async"    PINS="ppx_mysql:. ppx_mysql_async:."
+    - OCAML_VERSION=4.06 PACKAGE="ppx_mysql_async"    PINS="ppx_mysql:. ppx_mysql_async:." EXTRA_REMOTES="https://github.com/issuu/opam-repository-micro.git"

--- a/ppx_mysql.opam
+++ b/ppx_mysql.opam
@@ -1,17 +1,17 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Dario Teixeira <dte@issuu.com>"
 author: "Team Raccoon"
 homepage: "https://github.com/issuu/ppx_mysql"
-dev-repo: "https://github.com/issuu/ppx_mysql.git"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
 bug-reports: "https://github.com/issuu/ppx_mysql/issues"
 doc: "https://issuu.github.io/ppx_mysql/"
-available: [ ocaml-version >= "4.03.0" ]
 build: [["dune" "build" "-p" name "-j" jobs]]
-build-test: [["dune" "runtest" "-p" name]]
+run-test: [["dune" "runtest" "-p" name]]
 depends: [
-  "alcotest" {test & >= "0.8" & < "0.9"}
+  "alcotest" {with-test & >= "0.8" & < "0.9"}
   "dune" {build}
-  "ocamlformat" {test}
+  "ocamlformat" {with-test}
+  "ocaml" {>= "4.03.0" }
   "ppxlib" {>= "0.2" & < "0.4"}
-  "ppx_deriving" {test & >= "4.2" & < "5.0"}
+  "ppx_deriving" {with-test & >= "4.2" & < "5.0"}
 ]

--- a/ppx_mysql_async.opam
+++ b/ppx_mysql_async.opam
@@ -1,16 +1,16 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Dario Teixeira <dte@issuu.com>"
 author: "Team Raccoon"
 homepage: "https://github.com/issuu/ppx_mysql"
-dev-repo: "https://github.com/issuu/ppx_mysql.git"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
 bug-reports: "https://github.com/issuu/ppx_mysql/issues"
 doc: "https://issuu.github.io/ppx_mysql/"
-available: [ ocaml-version >= "4.03.0" ]
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "async" {>= "v0.11" & < "v0.12"}
   "dune" {build}
   "mysql" {>= "1.2" & < "2.0"}
+  "ocaml" {>= "4.03.0"}
   "ppx_mysql"
   "thread-pool-async" {>= "0.10.1" & < "0.11.0"}
 ]

--- a/ppx_mysql_identity.opam
+++ b/ppx_mysql_identity.opam
@@ -1,14 +1,14 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Dario Teixeira <dte@issuu.com>"
 author: "Team Raccoon"
 homepage: "https://github.com/issuu/ppx_mysql"
-dev-repo: "https://github.com/issuu/ppx_mysql.git"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
 bug-reports: "https://github.com/issuu/ppx_mysql/issues"
 doc: "https://issuu.github.io/ppx_mysql/"
-available: [ ocaml-version >= "4.03.0" ]
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {build}
   "mysql" {>= "1.2" & < "2.0"}
+  "ocaml" {>= "4.03.0"}
   "ppx_mysql"
 ]

--- a/ppx_mysql_lwt.opam
+++ b/ppx_mysql_lwt.opam
@@ -1,15 +1,15 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "Dario Teixeira <dte@issuu.com>"
 author: "Team Raccoon"
 homepage: "https://github.com/issuu/ppx_mysql"
-dev-repo: "https://github.com/issuu/ppx_mysql.git"
+dev-repo: "git+https://github.com/issuu/ppx_mysql.git"
 bug-reports: "https://github.com/issuu/ppx_mysql/issues"
 doc: "https://issuu.github.io/ppx_mysql/"
-available: [ ocaml-version >= "4.03.0" ]
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
   "dune" {build}
   "lwt" {>= "4.0" & < "5.0"}
   "mysql" {>= "1.2" & < "2.0"}
+  "ocaml" {>= "4.03.0"}
   "ppx_mysql"
 ]


### PR DESCRIPTION
In OPAM 2, `with-test` is preferred over just `test`. Moreover, we can use the `version` variable to force the subpackages to depend on the same version of the main package.