### PR TITLE
Remove descr file

### DIFF
--- a/ppx_mysql.descr
+++ b/ppx_mysql.descr
@@ -1,2 +1,0 @@
-PGOCaml/HugSQL/YeSQL like syntax extension for writing MySQL SQL code in
-OCaml source files.


### PR DESCRIPTION
The description moved into the OPAM (2.0) file, so no need for a standalone descr file.