### PR TITLE
Use the error monad inside the extension

### DIFF
--- a/lib/runtime/ppx_mysql_runtime.ml
+++ b/lib/runtime/ppx_mysql_runtime.ml
@@ -95,7 +95,6 @@ module Make_context (M : PPX_MYSQL_CONTEXT_ARG) :
           | Error _ as e ->
               IO.return e )
 
-
     let ( >>= ) = bind
   end
 

--- a/ppx/query.mli
+++ b/ppx/query.mli
@@ -20,6 +20,6 @@ type parse_error =
 
 (** {1 Public functions and values} *)
 
-val parse : string -> (parsed_query, parse_error) result
+val parse : string -> (parsed_query, [> parse_error]) result
 
-val explain_parse_error : parse_error -> string
+val explain_parse_error : [< parse_error] -> string


### PR DESCRIPTION
Note that the extension code itself still raises an exception
if it detects an error in the [%mysql] statements (this is the
standard way for a PPX to signal an error).  However, with this
commit there is now a single place where that fatal exception
is raised.

Note also that the code generated by the PPX still relies
on exceptions internally (removing them is a separate issue).