### PR TITLE
Implement Query.remove_duplicates

### DIFF
--- a/ppx/query.mli
+++ b/ppx/query.mli
@@ -18,8 +18,16 @@ type parse_error =
   | `Unterminated_string
   | `Escape_at_end ]
 
+type conflict_error = [`Conflicting_spec of string]
+
+type error =
+  [ parse_error
+  | conflict_error ]
+
 (** {1 Public functions and values} *)
 
 val parse : string -> (parsed_query, [> parse_error]) result
 
-val explain_parse_error : [< parse_error] -> string
+val remove_duplicates : param list -> (param list, [> conflict_error]) result
+
+val explain_error : [< error] -> string

--- a/ppx/query.mll
+++ b/ppx/query.mll
@@ -113,16 +113,16 @@ let remove_duplicates params =
   let rec loop dict accum = function
     | [] ->
         Ok (List.rev accum)
-    | hd :: tl ->
-        match Param_dict.find_opt hd.name dict with
+    | {name; typ; opt; _} as hd :: tl ->
+        match Param_dict.find_opt name dict with
         | None ->
-            let dict = Param_dict.add hd.name hd dict in
+            let dict = Param_dict.add name hd dict in
             let accum = hd :: accum in
             loop dict accum tl
-        | Some el when el.typ = hd.typ && el.opt = hd.opt ->
+        | Some el when el.typ = typ && el.opt = opt ->
             loop dict accum tl
         | Some _el ->
-            Error (`Conflicting_spec hd.name)
+            Error (`Conflicting_spec name)
   in
   loop Param_dict.empty [] params
 


### PR DESCRIPTION
This makes sure that input parameters which are used more than once
actually have the same type specification.  As a bonus, function
Ppx_mysql.build_fun_chain can be simplified since it can now expect
a list of unique input parameters.