### PR TITLE
Fix hygiene and add Lwt and Async examples

### DIFF
--- a/examples/hello_world_with_async/dune
+++ b/examples/hello_world_with_async/dune
@@ -1,0 +1,8 @@
+(executable
+    (name hello_world_with_async)
+    (libraries async mysql ppx_mysql.runtime)
+    (preprocess (pps ppx_mysql)))
+
+(alias
+  (name examples)
+  (deps hello_world_with_async.exe))

--- a/examples/hello_world_with_async/hello_world_with_async.ml
+++ b/examples/hello_world_with_async/hello_world_with_async.ml
@@ -1,0 +1,115 @@
+(* This example assumes that a Mysql database 'test' exists for user 'root'.
+ * Moreover, a table 'users' defined as follows is also present in the DB:
+ *  
+ * CREATE TABLE users
+ *     (
+ *     id    INT NOT NULL,
+ *     name  TEXT NOT NULL,
+ *     phone TEXT NULL,
+ *     PRIMARY KEY (id)
+ *     );
+ *)
+
+open Core
+open Async
+open Mysql_with_async
+
+(** Database queries using the Ppx_mysql syntax extension. *)
+
+let get_all_users =
+  [%mysql select_all "SELECT @int32{id}, @string{name}, @string?{phone} FROM users"]
+
+let get_some_users =
+  [%mysql
+    select_all
+      "SELECT @int32{id}, @string{name}, @string?{phone} FROM users WHERE id IN \
+       (%list{%int32{id}})"]
+
+let get_user =
+  [%mysql
+    select_one
+      "SELECT @int32{id}, @string{name}, @string?{phone} FROM users WHERE id = %int32{id}"]
+
+let insert_user =
+  [%mysql
+    execute
+      "INSERT INTO users (id, name, phone) VALUES (%int32{id}, %string{name}, \
+       %string?{phone})"]
+
+let insert_users =
+  [%mysql
+    execute
+      "INSERT INTO users (id, name, phone) VALUES %list{(%int32{id}, %string{name}, \
+       %string?{phone})}"]
+
+let update_user =
+  [%mysql
+    execute
+      "UPDATE users SET name = %string{name}, phone = %string?{phone} WHERE id = \
+       %int32{id}"]
+
+let delete_user = [%mysql execute "DELETE FROM users WHERE id = %int32{id}"]
+
+(** Main functions and values. *)
+
+let stdout = Lazy.force Writer.stdout
+
+let print_user (id, name, phone) =
+  Writer.writef
+    stdout
+    "%ld -> %s (phone: %s)\n"
+    id
+    name
+    ( match phone with
+    | Some p ->
+        p
+    | None ->
+        "--" )
+
+let test dbh =
+  let open Deferred.Result.Let_syntax in
+  insert_user dbh ~id:1l ~name:"John" ~phone:(Some "123456")
+  >>= fun () ->
+  insert_user dbh ~id:2l ~name:"Jane" ~phone:None
+  >>= fun () ->
+  insert_user dbh ~id:3l ~name:"Claire" ~phone:None
+  >>= fun () ->
+  insert_users dbh [4l, "Mark", None; 5l, "Alice", Some "234567"]
+  >>= fun () ->
+  get_all_users dbh
+  >>= fun users ->
+  Writer.writef stdout "All users:\n";
+  List.iter ~f:print_user users;
+  get_some_users dbh [1l; 2l; 3l]
+  >>= fun users ->
+  Writer.writef stdout "Users with ID in {1, 2, 3}:\n";
+  List.iter ~f:print_user users;
+  update_user dbh ~id:2l ~name:"Mary" ~phone:(Some "654321")
+  >>= fun () ->
+  get_user dbh ~id:2l
+  >>= fun user ->
+  Writer.writef stdout "User with ID = 2 after update:\n";
+  print_user user;
+  delete_user dbh ~id:3l
+  >>= fun () ->
+  get_all_users dbh
+  >>= fun users ->
+  Writer.writef stdout "All users after deleting one with ID = 3:\n";
+  List.iter ~f:print_user users;
+  return ()
+
+let main () =
+  let open Deferred.Let_syntax in
+  let dbh = Mysql.quick_connect ~database:"test" ~user:"root" () in
+  test dbh
+  >>= fun res ->
+  Mysql.disconnect dbh;
+  match res with
+  | Ok () ->
+      Writer.writef stdout "All went well!\n";
+      return ()
+  | Error _ ->
+      Writer.writef stdout "An error occurred!\n";
+      return ()
+
+let () = Command.(run @@ async ~summary:"Run Async example" @@ Param.return main)

--- a/examples/hello_world_with_async/mysql_with_async.ml
+++ b/examples/hello_world_with_async/mysql_with_async.ml
@@ -1,0 +1,32 @@
+open Async
+open Core
+
+include Ppx_mysql_runtime.Make_context (struct
+  module IO = struct
+    type 'a t = 'a Deferred.t
+
+    let return = Deferred.return
+
+    let bind x f = Deferred.bind x ~f
+  end
+
+  module Prepared = struct
+    type dbh = Mysql.dbd
+
+    type stmt = Mysql.Prepared.stmt
+
+    type stmt_result = Mysql.Prepared.stmt_result
+
+    type error = exn
+
+    let wrap f x = Deferred.return (try Ok (f x) with exc -> Error exc)
+
+    let create dbh sql = wrap (Mysql.Prepared.create dbh) sql
+
+    let close stmt = wrap Mysql.Prepared.close stmt
+
+    let execute_null stmt args = wrap (Mysql.Prepared.execute_null stmt) args
+
+    let fetch stmt_res = wrap Mysql.Prepared.fetch stmt_res
+  end
+end)

--- a/examples/hello_world_with_async/mysql_with_async.mli
+++ b/examples/hello_world_with_async/mysql_with_async.mli
@@ -1,0 +1,5 @@
+include
+  Ppx_mysql_runtime.PPX_MYSQL_CONTEXT
+  with type 'a IO.t = 'a Async.Deferred.t
+   and type Prepared.dbh = Mysql.dbd
+   and type Prepared.error = exn

--- a/examples/hello_world_with_identity/hello_world_with_identity.ml
+++ b/examples/hello_world_with_identity/hello_world_with_identity.ml
@@ -12,10 +12,7 @@
 
 open Mysql_with_identity
 
-(********************************************************************************)
-(** {1 Database queries using the Ppx_mysql syntax extension}                   *)
-
-(********************************************************************************)
+(** Database queries using the Ppx_mysql syntax extension. *)
 
 let get_all_users =
   [%mysql select_all "SELECT @int32{id}, @string{name}, @string?{phone} FROM users"]
@@ -51,10 +48,7 @@ let update_user =
 
 let delete_user = [%mysql execute "DELETE FROM users WHERE id = %int32{id}"]
 
-(********************************************************************************)
-(** {1 Main functions and values}                                               *)
-
-(********************************************************************************)
+(** Main functions and values. *)
 
 let print_user (id, name, phone) =
   Printf.printf
@@ -67,43 +61,45 @@ let print_user (id, name, phone) =
     | None ->
         "--" )
 
-let () =
-  let result =
-    let open IO_result in
-    let dbh = Mysql.quick_connect ~database:"test" ~user:"root" () in
-    insert_user dbh ~id:1l ~name:"John" ~phone:(Some "123456")
-    >>= fun () ->
-    insert_user dbh ~id:2l ~name:"Jane" ~phone:None
-    >>= fun () ->
-    insert_user dbh ~id:3l ~name:"Claire" ~phone:None
-    >>= fun () ->
-    insert_users dbh [4l, "Mark", None; 5l, "Alice", Some "234567"]
-    >>= fun () ->
-    get_all_users dbh
-    >>= fun users ->
-    Printf.printf "All users:\n";
-    List.iter print_user users;
-    get_some_users dbh [1l; 2l; 3l]
-    >>= fun users ->
-    Printf.printf "Users with ID in {1, 2, 3}:\n";
-    List.iter print_user users;
-    update_user dbh ~id:2l ~name:"Mary" ~phone:(Some "654321")
-    >>= fun () ->
-    get_user dbh ~id:2l
-    >>= fun user ->
-    Printf.printf "User with ID = 2 after update:\n";
-    print_user user;
-    delete_user dbh ~id:3l
-    >>= fun () ->
-    get_all_users dbh
-    >>= fun users ->
-    Printf.printf "All users after deleting one with ID = 3:\n";
-    List.iter print_user users;
-    Mysql.disconnect dbh;
-    Ok ()
-  in
-  match result with
+let test dbh =
+  let open IO_result in
+  insert_user dbh ~id:1l ~name:"John" ~phone:(Some "123456")
+  >>= fun () ->
+  insert_user dbh ~id:2l ~name:"Jane" ~phone:None
+  >>= fun () ->
+  insert_user dbh ~id:3l ~name:"Claire" ~phone:None
+  >>= fun () ->
+  insert_users dbh [4l, "Mark", None; 5l, "Alice", Some "234567"]
+  >>= fun () ->
+  get_all_users dbh
+  >>= fun users ->
+  Printf.printf "All users:\n";
+  List.iter print_user users;
+  get_some_users dbh [1l; 2l; 3l]
+  >>= fun users ->
+  Printf.printf "Users with ID in {1, 2, 3}:\n";
+  List.iter print_user users;
+  update_user dbh ~id:2l ~name:"Mary" ~phone:(Some "654321")
+  >>= fun () ->
+  get_user dbh ~id:2l
+  >>= fun user ->
+  Printf.printf "User with ID = 2 after update:\n";
+  print_user user;
+  delete_user dbh ~id:3l
+  >>= fun () ->
+  get_all_users dbh
+  >>= fun users ->
+  Printf.printf "All users after deleting one with ID = 3:\n";
+  List.iter print_user users;
+  Ok ()
+
+let main dbh =
+  match test dbh with
   | Ok () ->
-      print_endline "All went well!"
+      Printf.printf "All went well!\n"
   | Error _ ->
-      print_endline "An error occurred!"
+      Printf.printf "An error occurred!\n"
+
+let () =
+  let dbh = Mysql.quick_connect ~database:"test" ~user:"root" () in
+  main dbh; Mysql.disconnect dbh

--- a/examples/hello_world_with_identity/hello_world_with_identity.ml
+++ b/examples/hello_world_with_identity/hello_world_with_identity.ml
@@ -93,13 +93,14 @@ let test dbh =
   List.iter print_user users;
   Ok ()
 
-let main dbh =
-  match test dbh with
+let main () =
+  let dbh = Mysql.quick_connect ~database:"test" ~user:"root" () in
+  let res = test dbh in
+  Mysql.disconnect dbh;
+  match res with
   | Ok () ->
       Printf.printf "All went well!\n"
   | Error _ ->
       Printf.printf "An error occurred!\n"
 
-let () =
-  let dbh = Mysql.quick_connect ~database:"test" ~user:"root" () in
-  main dbh; Mysql.disconnect dbh
+let () = main ()

--- a/examples/hello_world_with_lwt/dune
+++ b/examples/hello_world_with_lwt/dune
@@ -1,0 +1,8 @@
+(executable
+    (name hello_world_with_lwt)
+    (libraries lwt lwt.unix mysql ppx_mysql.runtime)
+    (preprocess (pps ppx_mysql)))
+
+(alias
+  (name examples)
+  (deps hello_world_with_lwt.exe))

--- a/examples/hello_world_with_lwt/hello_world_with_lwt.ml
+++ b/examples/hello_world_with_lwt/hello_world_with_lwt.ml
@@ -1,0 +1,114 @@
+(* This example assumes that a Mysql database 'test' exists for user 'root'.
+ * Moreover, a table 'users' defined as follows is also present in the DB:
+ *  
+ * CREATE TABLE users
+ *     (
+ *     id    INT NOT NULL,
+ *     name  TEXT NOT NULL,
+ *     phone TEXT NULL,
+ *     PRIMARY KEY (id)
+ *     );
+ *)
+
+open Mysql_with_lwt
+
+(** Database queries using the Ppx_mysql syntax extension. *)
+
+let get_all_users =
+  [%mysql select_all "SELECT @int32{id}, @string{name}, @string?{phone} FROM users"]
+
+let get_some_users =
+  [%mysql
+    select_all
+      "SELECT @int32{id}, @string{name}, @string?{phone} FROM users WHERE id IN \
+       (%list{%int32{id}})"]
+
+let get_user =
+  [%mysql
+    select_one
+      "SELECT @int32{id}, @string{name}, @string?{phone} FROM users WHERE id = %int32{id}"]
+
+let insert_user =
+  [%mysql
+    execute
+      "INSERT INTO users (id, name, phone) VALUES (%int32{id}, %string{name}, \
+       %string?{phone})"]
+
+let insert_users =
+  [%mysql
+    execute
+      "INSERT INTO users (id, name, phone) VALUES %list{(%int32{id}, %string{name}, \
+       %string?{phone})}"]
+
+let update_user =
+  [%mysql
+    execute
+      "UPDATE users SET name = %string{name}, phone = %string?{phone} WHERE id = \
+       %int32{id}"]
+
+let delete_user = [%mysql execute "DELETE FROM users WHERE id = %int32{id}"]
+
+(** Main functions and values. *)
+
+let print_user (id, name, phone) =
+  Lwt_io.printf
+    "%ld -> %s (phone: %s)\n"
+    id
+    name
+    ( match phone with
+    | Some p ->
+        p
+    | None ->
+        "--" )
+
+let test dbh =
+  let open IO_result in
+  insert_user dbh ~id:1l ~name:"John" ~phone:(Some "123456")
+  >>= fun () ->
+  insert_user dbh ~id:2l ~name:"Jane" ~phone:None
+  >>= fun () ->
+  insert_user dbh ~id:3l ~name:"Claire" ~phone:None
+  >>= fun () ->
+  insert_users dbh [4l, "Mark", None; 5l, "Alice", Some "234567"]
+  >>= fun () ->
+  get_all_users dbh
+  >>= fun users ->
+  Lwt_result.ok @@ Lwt_io.printf "All users:\n"
+  >>= fun () ->
+  Lwt_result.ok @@ Lwt_list.iter_s print_user users
+  >>= fun () ->
+  get_some_users dbh [1l; 2l; 3l]
+  >>= fun users ->
+  Lwt_result.ok @@ Lwt_io.printf "Users with ID in {1, 2, 3}:\n"
+  >>= fun () ->
+  Lwt_result.ok @@ Lwt_list.iter_s print_user users
+  >>= fun () ->
+  update_user dbh ~id:2l ~name:"Mary" ~phone:(Some "654321")
+  >>= fun () ->
+  get_user dbh ~id:2l
+  >>= fun user ->
+  Lwt_result.ok @@ Lwt_io.printf "User with ID = 2 after update:\n"
+  >>= fun () ->
+  Lwt_result.ok @@ print_user user
+  >>= fun () ->
+  delete_user dbh ~id:3l
+  >>= fun () ->
+  get_all_users dbh
+  >>= fun users ->
+  Lwt_result.ok @@ Lwt_io.printf "All users after deleting one with ID = 3:\n"
+  >>= fun () ->
+  Lwt_result.ok @@ Lwt_list.iter_s print_user users >>= fun () -> Lwt_result.return ()
+
+let main dbh =
+  let open Lwt.Infix in
+  test dbh
+  >>= function
+  | Ok () ->
+      Lwt_io.printf "All went well!\n"
+  | Error _ ->
+      Lwt_io.printf "An error occurred!\n"
+
+let () =
+  let dbh = Mysql.quick_connect ~database:"test" ~user:"root" () in
+  Lwt_main.run @@ main dbh;
+  Mysql.disconnect dbh

--- a/examples/hello_world_with_lwt/hello_world_with_lwt.ml
+++ b/examples/hello_world_with_lwt/hello_world_with_lwt.ml
@@ -62,7 +62,7 @@ let print_user (id, name, phone) =
         "--" )
 
 let test dbh =
-  let open IO_result in
+  let open Lwt_result.Infix in
   insert_user dbh ~id:1l ~name:"John" ~phone:(Some "123456")
   >>= fun () ->
   insert_user dbh ~id:2l ~name:"Jane" ~phone:None
@@ -99,16 +99,16 @@ let test dbh =
   >>= fun () ->
   Lwt_result.ok @@ Lwt_list.iter_s print_user users >>= fun () -> Lwt_result.return ()
 
-let main dbh =
+let main () =
   let open Lwt.Infix in
+  let dbh = Mysql.quick_connect ~database:"test" ~user:"root" () in
   test dbh
-  >>= function
+  >>= fun res ->
+  Mysql.disconnect dbh;
+  match res with
   | Ok () ->
       Lwt_io.printf "All went well!\n"
   | Error _ ->
       Lwt_io.printf "An error occurred!\n"
 
-let () =
-  let dbh = Mysql.quick_connect ~database:"test" ~user:"root" () in
-  Lwt_main.run @@ main dbh;
-  Mysql.disconnect dbh
+let () = Lwt_main.run @@ main ()

--- a/examples/hello_world_with_lwt/mysql_with_lwt.ml
+++ b/examples/hello_world_with_lwt/mysql_with_lwt.ml
@@ -1,0 +1,27 @@
+include Ppx_mysql_runtime.Make_context (struct
+  module IO = Lwt
+
+  module Prepared = struct
+    type dbh = Mysql.dbd
+
+    type stmt = Mysql.Prepared.stmt
+
+    type stmt_result = Mysql.Prepared.stmt_result
+
+    type error = exn
+
+    let wrap f x =
+      let open Lwt.Infix in
+      Lwt.catch
+        (fun () -> Lwt_preemptive.detach f x >>= fun v -> Lwt.return_ok v)
+        (fun exn -> Lwt.return_error exn)
+
+    let create dbd sql = wrap (Mysql.Prepared.create dbd) sql
+
+    let close stmt = wrap Mysql.Prepared.close stmt
+
+    let execute_null stmt args = wrap (Mysql.Prepared.execute_null stmt) args
+
+    let fetch stmt_res = wrap Mysql.Prepared.fetch stmt_res
+  end
+end)

--- a/examples/hello_world_with_lwt/mysql_with_lwt.mli
+++ b/examples/hello_world_with_lwt/mysql_with_lwt.mli
@@ -1,0 +1,5 @@
+include
+  Ppx_mysql_runtime.PPX_MYSQL_CONTEXT
+  with type 'a IO.t = 'a Lwt.t
+   and type Prepared.dbh = Mysql.dbd
+   and type Prepared.error = exn

--- a/ppx/ppx_mysql.ml
+++ b/ppx/ppx_mysql.ml
@@ -276,9 +276,11 @@ let actually_expand ~loc sql_variant query =
                   (Ppx_mysql_runtime.Stdlib.String.append patch [%e sql_after])
               in
               let params_between =
-                Array.of_list
-                  (List.concat
-                     (List.map (fun [%p list_params_decl] -> [%e list_params_conv]) elems))
+                Ppx_mysql_runtime.Stdlib.Array.of_list
+                  (Ppx_mysql_runtime.Stdlib.List.concat
+                     (Ppx_mysql_runtime.Stdlib.List.map
+                        (fun [%p list_params_decl] -> [%e list_params_conv])
+                        elems))
               in
               let params =
                 Ppx_mysql_runtime.Stdlib.Array.concat

--- a/tests/test_ppx/test_ppx.expected.ml
+++ b/tests/test_ppx/test_ppx.expected.ml
@@ -947,9 +947,9 @@ let test_list0 dbh elems =
           (Ppx_mysql_runtime.Stdlib.String.append patch ")")
       in
       let params_between =
-        Array.of_list
-          (List.concat
-             (List.map
+        Ppx_mysql_runtime.Stdlib.Array.of_list
+          (Ppx_mysql_runtime.Stdlib.List.concat
+             (Ppx_mysql_runtime.Stdlib.List.map
                 (fun id ->
                   [Ppx_mysql_runtime.Stdlib.Option.Some (Pervasives.string_of_int id)] )
                 elems))
@@ -1036,9 +1036,9 @@ let test_list1 dbh elems =
           (Ppx_mysql_runtime.Stdlib.String.append patch "")
       in
       let params_between =
-        Array.of_list
-          (List.concat
-             (List.map
+        Ppx_mysql_runtime.Stdlib.Array.of_list
+          (Ppx_mysql_runtime.Stdlib.List.concat
+             (Ppx_mysql_runtime.Stdlib.List.map
                 (fun (id, name) ->
                   [ Ppx_mysql_runtime.Stdlib.Option.Some (Pervasives.string_of_int id)
                   ; Ppx_mysql_runtime.Stdlib.Option.Some
@@ -1092,9 +1092,9 @@ let test_list2 dbh elems ~(name : string) ~(age : int) =
           (Ppx_mysql_runtime.Stdlib.String.append patch ") OR age > ?")
       in
       let params_between =
-        Array.of_list
-          (List.concat
-             (List.map
+        Ppx_mysql_runtime.Stdlib.Array.of_list
+          (Ppx_mysql_runtime.Stdlib.List.concat
+             (Ppx_mysql_runtime.Stdlib.List.map
                 (fun id ->
                   [Ppx_mysql_runtime.Stdlib.Option.Some (Pervasives.string_of_int id)] )
                 elems))
@@ -1186,9 +1186,9 @@ let test_list3 dbh elems =
           (Ppx_mysql_runtime.Stdlib.String.append patch "")
       in
       let params_between =
-        Array.of_list
-          (List.concat
-             (List.map
+        Ppx_mysql_runtime.Stdlib.Array.of_list
+          (Ppx_mysql_runtime.Stdlib.List.concat
+             (Ppx_mysql_runtime.Stdlib.List.map
                 (fun (id, name, age) ->
                   [ Ppx_mysql_runtime.Stdlib.Option.Some (Pervasives.string_of_int id)
                   ; Ppx_mysql_runtime.Stdlib.Option.Some


### PR DESCRIPTION
This PR fixes a hygiene lapse and adds examples for Lwt and Async.

The Async example has the added benefit that it also relies on hygiene being preserved. If it fails to compile there's a good chance a hygiene regression was introduced.