### PR TITLE
Widen allowed ppxlib versions

### DIFF
--- a/ppx_mysql.opam
+++ b/ppx_mysql.opam
@@ -20,6 +20,6 @@ depends: [
   "dune" {build}
   "ocamlformat" {with-test & >= "0.9"}
   "ocaml" {>= "4.06.0" }
-  "ppxlib" {>= "0.6"}
+  "ppxlib" {>= "0.2"}
   "ppx_deriving" {with-test & >= "4.2" & < "5.0"}
 ]

--- a/ppx_mysql.opam
+++ b/ppx_mysql.opam
@@ -20,6 +20,6 @@ depends: [
   "dune" {build}
   "ocamlformat" {with-test & >= "0.9"}
   "ocaml" {>= "4.06.0" }
-  "ppxlib" {>= "0.2" & < "0.6"}
+  "ppxlib" {>= "0.6"}
   "ppx_deriving" {with-test & >= "4.2" & < "5.0"}
 ]


### PR DESCRIPTION
This widens the allowed versions of ppxlib to any version after 0.2. This includes 0.6 which is used by enough of the janestreet and derived world that conflict prevented building in an httpaf/core/async environment. 