### PR TITLE
Depend on newer dune specified in dune-project

### DIFF
--- a/ppx_mysql.opam
+++ b/ppx_mysql.opam
@@ -18,7 +18,7 @@ build: [
 depends: [
   "alcotest" {with-test & >= "0.8" & < "0.9"}
   "dune" {>= "1.4"}
-  "ocamlformat" {with-test & >= "0.9"}
+  "ocamlformat" {with-test & >= "0.9" & < "0.10"}
   "ocaml" {>= "4.06.0" }
   "ppxlib" {>= "0.2" & < "0.9"}
   "ppx_deriving" {with-test & >= "4.2" & < "5.0"}

--- a/ppx_mysql.opam
+++ b/ppx_mysql.opam
@@ -17,7 +17,7 @@ build: [
 ]
 depends: [
   "alcotest" {with-test & >= "0.8" & < "0.9"}
-  "dune" {build}
+  "dune" {>= "1.4"}
   "ocamlformat" {with-test & >= "0.9"}
   "ocaml" {>= "4.06.0" }
   "ppxlib" {>= "0.2" & < "0.9"}

--- a/ppx_mysql_identity.opam
+++ b/ppx_mysql_identity.opam
@@ -13,7 +13,7 @@ bug-reports: "https://github.com/issuu/ppx_mysql/issues"
 doc: "https://issuu.github.io/ppx_mysql/"
 build: [["dune" "build" "-p" name "-j" jobs]]
 depends: [
-  "dune" {build}
+  "dune" {>= "1.4"}
   "mysql" {>= "1.2" & < "2.0"}
   "ocaml" {>= "4.06.0"}
   "ppx_mysql" {= version}


### PR DESCRIPTION
It failed to build for me because my dune version was too old and letting dune install dependencies did not update it, so this PR requires at least dune 1.4.