### PR TITLE
Remove the upper limit on ppxlib

### DIFF
--- a/ppx_mysql.opam
+++ b/ppx_mysql.opam
@@ -21,6 +21,6 @@ depends: [
   "ocamlformat" {with-test & >= "0.9" & < "0.10"}
   "ocaml" {>= "4.06.0" }
   "ppx_deriving" {with-test & >= "4.2" & < "5.0"}
-  "ppxlib" {>= "0.2" & < "0.9"}
+  "ppxlib" {>= "0.2"}
   "stdlib-shims"
 ]


### PR DESCRIPTION
It works with the current 0.12 at least and 0.9 blocks installation of JST v0.13 packages.