### PR TITLE
Remove version constraints on alcotest

### DIFF
--- a/ppx_mysql.opam
+++ b/ppx_mysql.opam
@@ -16,7 +16,7 @@ build: [
   ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
 depends: [
-  "alcotest" {with-test & >= "0.8" & < "0.9"}
+  "alcotest" {with-test}
   "dune" {>= "1.4"}
   "ocamlformat" {with-test & >= "0.9" & < "0.10"}
   "ocaml" {>= "4.06.0" }


### PR DESCRIPTION
This project's tests build and pass with the latest version, and upper bound on alcotest was previously < 0.9 which is no longer in the opam repository.